### PR TITLE
Do not use set use_agent, but set gpg binary to gpg2

### DIFF
--- a/application/nativePass
+++ b/application/nativePass
@@ -67,7 +67,7 @@ def get_list(pattern):
 # a unique existing gpg file inside the password store.
 def get_pass(path):
   password = ""
-  gpg = gnupg.GPG(use_agent=True)
+  gpg = gnupg.GPG(gpgbinary="gpg2")
   txt = open(get_store_path() + "/" + path + ".gpg", "rb")
   data = gpg.decrypt_file(txt)
   if data.ok:


### PR DESCRIPTION
At least in my setup, use_agent does not have to be manually set to "true" to make this work, I think gpg2 uses it by default.. `python-gnupg` uses gpg1 by default though, which, to me, does not make sense. Therefore I changed it to gpg2. This is tested on Ubuntu 16.04, not on any other platform