### PR TITLE
Add default hotkey to the manifest

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,6 +20,13 @@
     "default_title": "pass",
     "default_popup": "popup.html"
   },
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+P"
+      }
+    }
+  },
   "content_scripts": [
     {
       "js": ["content.js"],


### PR DESCRIPTION
Based on this one:
https://github.com/FelisCatus/SwitchyOmega/blob/b93171da95fdcd0d0218a76b90178f74afa7aec5/omega-target-chromium-extension/overlay/manifest.json#L54

Did not have a chance to do the proper test though.
This should finally fix #7.
Default hotkey is set to `Alt+Shift+P`.